### PR TITLE
Some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /output
 /env/
 __pycache__/
+/wandb

--- a/model/engine/inference.py
+++ b/model/engine/inference.py
@@ -14,6 +14,7 @@ def inference_for_ss(args, cfg, model, test_loader):
     """
     aiu_scoures : test_case(=len(test_loader)) x threshold_case(=99)
     """
+    global aiu_scores
     fnames = []
     max_iter = len(test_loader)
 
@@ -30,7 +31,6 @@ def inference_for_ss(args, cfg, model, test_loader):
     if args.test_aiu:
         thresholds = [i*0.01 for i in range(1, 100)]
         iou_mode = "AIU"
-        
     else:
         thresholds = [0.5]
         iou_mode = "IoU"

--- a/test.py
+++ b/test.py
@@ -48,7 +48,7 @@ def test(args, cfg):
         inference_for_ss(args, cfg, model, test_loader)
 
 def main():
-    parser = argparse.ArgumentParser(description='Crack Segmentation with Super Resolution(CSSR))
+    parser = argparse.ArgumentParser(description='Crack Segmentation with Super Resolution(CSSR)')
     parser.add_argument('test_dir', type=str, default=None)
     parser.add_argument('iteration', type=int, default=None)
 
@@ -57,7 +57,8 @@ def main():
     parser.add_argument('--num_workers', type=int, default=8)
     parser.add_argument('--batch_size', type=int, default=16)
     parser.add_argument('--num_gpus', type=int, default=6)
-    parser.add_argument('--test_aiu', type=bool, default=True)
+    parser.add_argument('--test_aiu', type=bool, default=False)
+    #parser.add_argument('--test_aiu', action=argparse.BooleanOptionalAction)
     parser.add_argument('--trained_model', type=str, default=None)
     parser.add_argument('--wandb_flag', type=bool, default=True)
     parser.add_argument('--wandb_prj_name', type=str, default="CSSR_kyoken_test_blur")


### PR DESCRIPTION
Typo fix in : parser = argparse.ArgumentParser(description='Crack Segmentation with Super Resolution(CSSR)').
Added dir wandb in gitignore.
Declared global aiu_scores because of error in print() outside for loop. The variable goes out-of-scope. I could initialize it with the right type but haven't found a way.

